### PR TITLE
RFC: update syntax

### DIFF
--- a/src/BitmappedVectorTrie.jl
+++ b/src/BitmappedVectorTrie.jl
@@ -1,3 +1,5 @@
+# implements Tries
+
 # `shiftby` is equal to the number of bits required to represent index information
 # for one level of the BitmappedTrie.
 #
@@ -42,3 +44,244 @@ function Base.isequal(t1::BitmappedTrie, t2::BitmappedTrie)
 end
 
 ==(t1::BitmappedTrie, t2::BitmappedTrie) = isequal(t1, t2)
+
+
+# Dense Bitmapped Tries
+# =====================
+
+abstract DenseBitmappedTrie{T} <: BitmappedTrie{T}
+
+# Why is the shift value of a DenseLeaf 5 instead of 0, and why does
+# the shift value of a DenseNode start at 10?
+#
+# The PersistentVector implements a "tail" optimization, where it
+# inserts appended elements into a tail array until that array is 32
+# elements long, only then inserting it into the actual bitmapped
+# vector trie. This significantly increases the performance of
+# operations that touch the very end of the vector (last, append, pop,
+# etc.) because you don't have to traverse the trie.
+#
+# However, it adds a small amount of complexity to the implementation;
+# when you query the trie, you now get back a length-32 array instead
+# of the actual element. This is why the DenseLeaf has a shift value
+# of 5: it leaves an "extra" 5 bits for the PersistentVector to use to
+# index into the array returned from the trie. (This also means that a
+# DenseNode has to start at shiftby*2.)
+
+immutable DenseNode{T} <: DenseBitmappedTrie{T}
+    arr::Vector{DenseBitmappedTrie{T}}
+    shift::Int
+    length::Int
+    maxlength::Int
+end
+
+immutable DenseLeaf{T} <: DenseBitmappedTrie{T}
+    arr::Vector{T}
+
+    DenseLeaf(arr::Vector) = new(arr)
+    DenseLeaf() = new(T[])
+end
+
+arrayof(    node::DenseNode) = node.arr
+shift(      node::DenseNode) = node.shift
+maxlength(  node::DenseNode) = node.maxlength
+Base.length(node::DenseNode) = node.length
+
+arrayof(    leaf::DenseLeaf) = leaf.arr
+shift(          ::DenseLeaf) = shiftby
+maxlength(  leaf::DenseLeaf) = trielen
+Base.length(leaf::DenseLeaf) = length(arrayof(leaf))
+
+function promoted{T}(node::DenseBitmappedTrie{T})
+    DenseNode{T}(DenseBitmappedTrie{T}[node],
+                 shift(node) + shiftby,
+                 length(node),
+                 maxlength(node) * trielen)
+end
+
+function demoted{T}(node::DenseNode{T})
+    if shift(node) == shiftby * 2
+        DenseLeaf{T}(T[])
+    else
+        DenseNode{T}(DenseBitmappedTrie{T}[],
+                     shift(node) - shiftby,
+                     0,
+                     round(Int, maxlength(node) / trielen))
+    end
+end
+
+function witharr{T}(node::DenseNode{T}, arr::Array, lenshift::Int=0)
+    DenseNode{T}(arr, shift(node), length(node) + lenshift, maxlength(node))
+end
+witharr{T}(leaf::DenseLeaf{T}, arr::Array) = DenseLeaf{T}(arr)
+
+function append(leaf::DenseLeaf, el)
+    if length(leaf) < maxlength(leaf)
+        newarr = copy_to_len(arrayof(leaf), 1 + length(leaf))
+        newarr[end] = el
+        witharr(leaf, newarr)
+    else
+        append(promoted(leaf), el)
+    end
+end
+function append{T}(node::DenseNode{T}, el)
+    if length(node) == 0
+        child = append(demoted(node), el)
+        witharr(node, DenseBitmappedTrie{T}[child], 1)
+    elseif length(node) < maxlength(node)
+        if length(arrayof(node)[end]) == maxlength(arrayof(node)[end])
+            newarr = copy_to_len(arrayof(node), 1 + length(arrayof(node)))
+            newarr[end] = append(demoted(node), el)
+            witharr(node, newarr, 1)
+        else
+            newarr = arrayof(node)[:]
+            newarr[end] = append(newarr[end], el)
+            witharr(node, newarr, 1)
+        end
+    else
+        append(promoted(node), el)
+    end
+end
+push(leaf::DenseLeaf, el) = append(leaf, el)
+push(node::DenseNode, el) = append(node, el)
+
+Base.getindex(leaf::DenseLeaf, i::Int) = arrayof(leaf)[mask(leaf, i)]
+Base.getindex(node::DenseNode, i::Int) = arrayof(node)[mask(node, i)][i]
+
+function assoc{T}(leaf::DenseLeaf{T}, i::Int, el)
+    newarr = arrayof(leaf)[:]
+    newarr[mask(leaf, i)] = el
+    DenseLeaf{T}(newarr)
+end
+function assoc(node::DenseNode, i::Int, el)
+    newarr = arrayof(node)[:]
+    idx = mask(node, i)
+    newarr[idx] = assoc(newarr[idx], i, el)
+    witharr(node, newarr)
+end
+
+peek(bt::DenseBitmappedTrie) = bt[end]
+
+# Pop is usually destructive, but that doesn't make sense for an immutable
+# structure, so `pop` is defined to return a Trie without its last
+# element. Use `peek` to access the last element.
+#
+pop(leaf::DenseLeaf) = witharr(leaf, arrayof(leaf)[1:end-1])
+function pop(node::DenseNode)
+    newarr = arrayof(node)[:]
+    newarr[end] = pop(newarr[end])
+    witharr(node, newarr, -1)
+end
+
+# Sparse Bitmapped Tries
+# ======================
+
+abstract SparseBitmappedTrie{T} <: BitmappedTrie{T}
+
+immutable SparseNode{T} <: SparseBitmappedTrie{T}
+    arr::Vector{SparseBitmappedTrie{T}}
+    shift::Int
+    length::Int
+    maxlength::Int
+    bitmap::Int
+end
+SparseNode(T::Type) = SparseNode{T}(SparseBitmappedTrie{T}[], shiftby*7, 0, trielen^7, 0)
+
+immutable SparseLeaf{T} <: SparseBitmappedTrie{T}
+    arr::Vector{T}
+    bitmap::Int
+
+    SparseLeaf(arr::Vector, bitmap::Int) = new(arr, bitmap)
+    SparseLeaf() = new(T[], 0)
+end
+
+arrayof(    n::SparseNode) = n.arr
+shift(      n::SparseNode) = n.shift
+maxlength(  n::SparseNode) = n.maxlength
+Base.length(n::SparseNode) = n.length
+
+arrayof(    l::SparseLeaf) = l.arr
+shift(       ::SparseLeaf) = 0
+maxlength(  l::SparseLeaf) = trielen
+Base.length(l::SparseLeaf) = length(arrayof(l))
+
+function demoted{T}(n::SparseNode{T})
+    shift(n) == shiftby ?
+    SparseLeaf{T}(T[], 0) :
+    SparseNode{T}(SparseBitmappedTrie{T}[],
+                  shift(n) - shiftby,
+                  0,
+                  round(Int, maxlength(n) / trielen), 0)
+end
+
+bitpos(  t::SparseBitmappedTrie, i::Int) = 1 << (mask(t, i) - 1)
+hasindex(t::SparseBitmappedTrie, i::Int) = t.bitmap & bitpos(t, i) != 0
+index(   t::SparseBitmappedTrie, i::Int) =
+    1 + count_ones(t.bitmap & (bitpos(t, i) - 1))
+
+function update{T}(l::SparseLeaf{T}, i::Int, el::T)
+    hasi = hasindex(l, i)
+    bitmap = bitpos(l, i) | l.bitmap
+    idx = index(l, i)
+    if hasi
+        newarr = arrayof(l)[:]
+        newarr[idx] = el
+    else
+        newarr = vcat(arrayof(l)[1:idx-1], [el], arrayof(l)[idx:end])
+    end
+    (SparseLeaf{T}(newarr, bitmap), !hasi)
+end
+function update{T}(n::SparseNode{T}, i::Int, el::T)
+    bitmap = bitpos(n, i) | n.bitmap
+    idx = index(n, i)
+    if hasindex(n, i)
+        newarr = arrayof(n)[:]
+        updated, inc = update(newarr[idx], i, el)
+        newarr[idx] = updated
+    else
+        child, inc = update(demoted(n), i, el)
+        newarr = vcat(arrayof(n)[1:idx-1], [child], arrayof(n)[idx:end])
+    end
+    (SparseNode{T}(newarr,
+                   n.shift,
+                   inc ? n.length + 1 : n.length,
+                   n.maxlength, bitmap),
+     inc)
+end
+
+Base.get(n::SparseLeaf, i::Int, default) =
+    hasindex(n, i) ? arrayof(n)[index(n, i)] : default
+Base.get(n::SparseNode, i::Int, default) =
+    hasindex(n, i) ? get(arrayof(n)[index(n, i)], i, default) : default
+
+function Base.start(t::SparseBitmappedTrie)
+    t.length == 0 && return []
+    ones(Int, 1 + round(Int, t.shift / shiftby)) # state
+end
+
+function directindex(t::SparseBitmappedTrie, v::Vector{Int})
+    isempty(v) && return arrayof(t)
+    local node = arrayof(t)
+    for i=v
+        node = node[i]
+        node = isa(node, SparseBitmappedTrie) ? arrayof(node) : node
+    end
+    node
+end
+
+Base.done(t::SparseBitmappedTrie, state) = isempty(state)
+
+function Base.next(t::SparseBitmappedTrie, state::Vector{Int})
+    item = directindex(t, state)
+    while true
+        index = pop!(state)
+        node = directindex(t, state)
+        if length(node) > index
+            push!(state, index + 1)
+            return item, vcat(state, ones(Int, 1 + round(Int, t.shift / shiftby) -
+                                               length(state)))
+        elseif node === arrayof(t)
+            return item, []
+        end
+    end
+end

--- a/src/FunctionalCollections.jl
+++ b/src/FunctionalCollections.jl
@@ -1,7 +1,6 @@
 module FunctionalCollections
 
 import Base.==
-using Compat
 
 include("BitmappedVectorTrie.jl")
 
@@ -16,8 +15,6 @@ export PersistentVector, pvec,
        pop
 
 include("PersistentMap.jl")
-include("PersistentArrayMap.jl")
-include("PersistentHashMap.jl")
 
 typealias phmap PersistentHashMap
 
@@ -61,11 +58,11 @@ end
 macro Persistent(ex)
     hd = ex.head
 
-    if is(hd, :vcat) || is(hd, :cell1d) || is(hd, :vect)
+    if (hd === :vcat) || (hd === :cell1d) || (hd === :vect)
         fromexpr(ex, pvec)
-    elseif is(hd, :call) && is(ex.args[1], :Set)
+    elseif (hd === :call) && (ex.args[1] === :Set)
         fromexpr(ex, pset)
-    elseif is(hd, :dict) || (is(hd, :call) && is(ex.args[1], :Dict))
+    elseif (hd === :dict) || ((hd === :call) && (ex.args[1] === :Dict))
         fromexpr(ex, phmap)
     else
         error("Unsupported @Persistent syntax")

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -53,12 +53,12 @@ Base.next(::AbstractList, l::PersistentList) = (head(l), tail(l))
 
 Base.isequal(a::AbstractArray, l::PersistentList) = isequal(l, a)
 Base.isequal(l::PersistentList, a::AbstractArray) =
-    isequal(length(l), length(a)) && all((el) -> el[1] == el[2], zip(l, a))
+    isequal(length(l), length(a)) && all((el) -> el[1] == el[2], zipd(l, a))
 ==(a::AbstractArray, l::PersistentList) = isequal(l, a)
 ==(l::PersistentList, a::AbstractArray) = isequal(l, a)
 
-Base.map(f::(@compat Union{Function, DataType}), e::EmptyList) = e
-Base.map(f::(@compat Union{Function, DataType}), l::PersistentList) = cons(f(head(l)), map(f, tail(l)))
+Base.map(f::( Union{Function, DataType}), e::EmptyList) = e
+Base.map(f::( Union{Function, DataType}), l::PersistentList) = cons(f(head(l)), map(f, tail(l)))
 
 Base.reverse(e::EmptyList) = e
 function Base.reverse{T}(l::PersistentList{T})
@@ -69,8 +69,8 @@ function Base.reverse{T}(l::PersistentList{T})
     reversed
 end
 
-@compat Base.show(io::IO, ::MIME"text/plain", ::EmptyList) = print(io, "()")
-@compat function Base.show{T}(io::IO, ::MIME"text/plain", l::PersistentList{T})
+ Base.show(io::IO, ::MIME"text/plain", ::EmptyList) = print(io, "()")
+ function Base.show{T}(io::IO, ::MIME"text/plain", l::PersistentList{T})
     print(io, "$T($(head(l))")
     for val in tail(l)
         print(io, ", $val")

--- a/src/PersistentMap.jl
+++ b/src/PersistentMap.jl
@@ -2,23 +2,212 @@ abstract PersistentMap{K, V} <: Associative{K, V}
 
 type NotFound end
 
-immutable KVPair{K, V}
-    key::K
-    value::V
+immutable PersistentArrayMap{K, V} <: PersistentMap{K, V}
+    kvs::Vector{Pair{K, V}}
+
+    PersistentArrayMap(kvs::Vector{Pair{K, V}}) = new(kvs)
+    PersistentArrayMap() = new(Pair{K, V}[])
+end
+PersistentArrayMap{K, V}(kvs::(Tuple{K, V})...) =
+    PersistentArrayMap{K, V}(Pair{K, V}[Pair(k, v) for (k, v) in kvs])
+PersistentArrayMap(; kwargs...) = PersistentArrayMap(kwargs...)
+
+Base.isequal(m1::PersistentArrayMap, m2::PersistentArrayMap) =
+    isequal(Set(m1.kvs), Set(m2.kvs))
+==(m1::PersistentArrayMap, m2::PersistentArrayMap) =
+    Set(m1.kvs) == Set(m2.kvs)
+
+Base.length(m::PersistentArrayMap)  = length(m.kvs)
+Base.isempty(m::PersistentArrayMap) = length(m) == 0
+
+findkeyidx(m::PersistentArrayMap, k) = findfirst(kv -> kv[1] == k, m.kvs)
+
+function _get(m::PersistentArrayMap, k, default, hasdefault::Bool)
+    for kv in m.kvs
+        kv[1] == k && return kv[2]
+    end
+    hasdefault ? default : default()
 end
 
-Base.convert(::Type{Tuple}, kv::KVPair) = (kv.key, kv.value)
-Base.convert{K, V}(::Type{KVPair{K, V}}, kv::KVPair) =
-    KVPair{K, V}(convert(K, kv.key), convert(V, kv.value))
+Base.get(m::PersistentArrayMap, k) =
+    _get(m, k, ()->error("key not found: $k"), false)
+Base.get(m::PersistentArrayMap, k, default) =
+    _get(m, k, default, true)
+Base.getindex(m::PersistentArrayMap, k) = get(m, k)
 
-Base.isequal(kv1::KVPair, kv2::KVPair) =
-    isequal(kv1.key, kv2.key) && isequal(kv1.value, kv2.value)
-Base.isequal(kv::KVPair, tup::Tuple) = isequal(convert(Tuple, kv), tup)
-Base.isequal(tup::Tuple, kv::KVPair) = isequal(kv, tup)
-==(kv1::KVPair, kv2::KVPair) = kv1.key == kv2.key && kv1.value == kv2.value
-==(kv::KVPair, tup::Tuple) = convert(Tuple, kv) == tup
-==(tup::Tuple, kv::KVPair) = kv == tup
+Base.haskey(m::PersistentArrayMap, k) = get(m, k, NotFound()) != NotFound()
 
-Base.hash(kv::KVPair) = @compat UInt(Base.hash(kv.key, hash(kv.value)))
+function assoc{K, V}(m::PersistentArrayMap{K, V}, k, v)
+    idx = findkeyidx(m, k)
+    idx == 0 && return PersistentArrayMap{K, V}(push!(m.kvs[1:end], Pair(k, v)))
 
-@compat Base.show(io::IO, ::MIME"text/plain", kv::KVPair) = print(io, "$(kv.key) => $(kv.value)")
+    kvs = m.kvs[1:end]
+    kvs[idx] = Pair(k, v)
+    PersistentArrayMap{K, V}(kvs)
+end
+
+function dissoc{K, V}(m::PersistentArrayMap{K, V}, k)
+    idx = findkeyidx(m, k)
+    idx == 0 && return m
+
+    kvs = m.kvs[1:end]
+    splice!(kvs, idx)
+    PersistentArrayMap{K, V}(kvs)
+end
+
+Base.start(m::PersistentArrayMap)   = 1
+Base.done(m::PersistentArrayMap, i) = i > length(m)
+Base.next(m::PersistentArrayMap, i) = (m.kvs[i], i+1)
+
+Base.map(f::( Union{DataType, Function}), m::PersistentArrayMap) =
+    PersistentArrayMap([f(kv) for kv in m]...)
+
+Base.show{K, V}(io::IO, ::MIME"text/plain", m::PersistentArrayMap{K, V}) =
+    print(io, "Persistent{$K, $V}$(m.kvs)")
+
+
+# Persistent Hash Maps
+# ====================
+
+immutable PersistentHashMap{K, V} <: PersistentMap{K, V}
+    trie::SparseBitmappedTrie{PersistentArrayMap{K, V}}
+    length::Int
+
+    PersistentHashMap(trie, length) = new(trie, length)
+    PersistentHashMap() = new(SparseNode(PersistentArrayMap{K, V}), 0)
+end
+
+function PersistentHashMap(itr)
+    if length(itr) == 0
+        return PersistentHashMap()
+    end
+    if VERSION >= v"0.4.0-dev"
+        K, V = typejoin(map(typeof, itr)...).types
+    else
+        K, V = typejoin(map(typeof, itr)...)
+    end
+    m = PersistentHashMap{K, V}()
+    for (k, v) in itr
+        m = assoc(m, k, v)
+    end
+    m
+end
+
+function PersistentHashMap(kvs::(Tuple{Any, Any})...)
+    PersistentHashMap([kvs...])
+end
+
+function PersistentHashMap(kvs::(Pair)...)
+    PersistentHashMap([kvs...])
+end
+
+function PersistentHashMap(; kwargs...)
+    isempty(kwargs) ?
+    PersistentHashMap{Any, Any}() :
+    PersistentHashMap(kwargs...)
+end
+
+Base.length(m::PersistentHashMap) = m.length
+Base.isempty(m::PersistentHashMap) = length(m) == 0
+
+zipd(x,y) = map(p -> p[1] => p[2], zip(x,y))
+Base.isequal(m1::PersistentHashMap, m2::PersistentHashMap) =
+    length(m1) == length(m2) && all(x -> isequal(x...), zipd(m1, m2))
+
+tup_eq(x) = x[1] == x[2]
+==(m1::PersistentHashMap, m2::PersistentHashMap) =
+    length(m1) == length(m2) && all(x -> x[1] == x[2], zipd(m1, m2))
+
+function _update{K, V}(f::Function, m::PersistentHashMap{K, V}, key)
+    keyhash = reinterpret(Int, hash(key))
+    arraymap = get(m.trie, keyhash, PersistentArrayMap{K, V}())
+    newmap = f(arraymap)
+    newtrie, _ = update(m.trie, keyhash, newmap)
+    PersistentHashMap{K, V}(newtrie,
+                            m.length + (length(newmap) < length(arraymap) ? -1 :
+                                        length(newmap) > length(arraymap) ? 1 :
+                                        0))
+end
+
+function assoc{K, V}(m::PersistentHashMap{K, V}, key, value)
+    _update(m, key) do arraymap
+        assoc(arraymap, key, value)
+    end
+end
+
+function dissoc(m::PersistentHashMap, key)
+    _update(m, key) do arraymap
+        dissoc(arraymap, key)
+    end
+end
+
+function Base.getindex(m::PersistentHashMap, key)
+    val = get(m.trie, reinterpret(Int, hash(key)), NotFound())
+    (val === NotFound()) && error("key not found")
+    val[key]
+end
+
+Base.get(m::PersistentHashMap, key) = m[key]
+function Base.get(m::PersistentHashMap, key, default)
+    val = get(m.trie, reinterpret(Int, hash(key)), NotFound())
+    (val === NotFound()) && return default
+    val[key]
+end
+
+function Base.haskey(m::PersistentHashMap, key)
+    get(m.trie, reinterpret(Int, hash(key)), NotFound()) != NotFound()
+end
+
+function Base.start(m::PersistentHashMap)
+    state = start(m.trie)
+    done(m.trie, state) && return (Any[], state)
+    arrmap, triestate = next(m.trie, state)
+    (arrmap.kvs, triestate)
+end
+Base.done(m::PersistentHashMap, state) =
+    isempty(state[1]) && done(m.trie, state[2])
+
+function Base.next(m::PersistentHashMap, state)
+    kvs, triestate = state
+    if isempty(kvs)
+        arrmap, triestate = next(m.trie, triestate)
+        next(m, (arrmap.kvs, triestate))
+    else
+        (kvs[1], (kvs[2:end], triestate))
+    end
+end
+
+function Base.map(f::( Union{Function, DataType}), m::PersistentHashMap)
+    PersistentHashMap([f(kv) for kv in m]...)
+end
+
+function Base.filter{K, V}(f::Function, m::PersistentHashMap{K, V})
+    arr = Array((Pair{K, V}), 0)
+    for el in m
+        f(el) && push!(arr, el)
+    end
+    isempty(arr) ? PersistentHashMap{K, V}() : PersistentHashMap(arr...)
+end
+
+# Suppress ambiguity warning while allowing merging with array
+function _merge(d::PersistentHashMap, others...)
+    acc = d
+    for other in others
+        for (k, v) in other
+            acc = assoc(acc, k, v)
+        end
+    end
+    acc
+end
+
+# This definition suppresses ambiguity warning
+Base.merge(d::PersistentHashMap, others::Associative...) =
+    _merge(d, others...)
+Base.merge(d::PersistentHashMap, others...) =
+    _merge(d, others...)
+
+ function Base.show{K, V}(io::IO, ::MIME"text/plain", m::PersistentHashMap{K, V})
+    print(io, "Persistent{$K, $V}[")
+    print(io, join(["$k => $v" for (k, v) in m], ", "))
+    print(io, "]")
+end

--- a/src/PersistentQueue.jl
+++ b/src/PersistentQueue.jl
@@ -15,7 +15,7 @@ PersistentQueue{T}(v::AbstractVector{T}) =
 queue = PersistentQueue
 
 Base.length(q::PersistentQueue) = q.length
-Base.isempty(q::PersistentQueue) = is(q.length, 0)
+Base.isempty(q::PersistentQueue) = (q.length === 0)
 
 peek(q::PersistentQueue) = isempty(q.out) ? head(reverse(q.in)) : head(q.out)
 
@@ -34,15 +34,15 @@ enq{T}(q::PersistentQueue{T}, val) =
     end
 
 Base.start(q::PersistentQueue) = (q.in, q.out)
-Base.done{T}(::PersistentQueue{T}, state::(@compat Tuple{EmptyList{T}, EmptyList{T}})) = true
+Base.done{T}(::PersistentQueue{T}, state::(Tuple{EmptyList{T}, EmptyList{T}})) = true
 Base.done(::PersistentQueue, state) = false
 
-function Base.next{T}(::PersistentQueue{T}, state::(@compat Tuple{AbstractList{T},
+function Base.next{T}(::PersistentQueue{T}, state::(Tuple{AbstractList{T},
                                                                   PersistentList{T}}))
     in, out = state
     (head(out), (in, tail(out)))
 end
-function Base.next{T}(q::PersistentQueue{T}, state::(@compat Tuple{PersistentList{T},
+function Base.next{T}(q::PersistentQueue{T}, state::(Tuple{PersistentList{T},
                                                                    EmptyList{T}}))
     in, out = state
     next(q, (EmptyList{T}(), reverse(in)))

--- a/src/PersistentSet.jl
+++ b/src/PersistentSet.jl
@@ -1,9 +1,9 @@
 immutable PersistentSet{T}
-    dict::PersistentHashMap{T, (@compat Void)}
+    dict::PersistentHashMap{T, Void}
 
-    PersistentSet(d::PersistentHashMap{T, (@compat Void)}) = new(d)
-    PersistentSet() = new(PersistentHashMap{T, (@compat Void)}())
-    PersistentSet(itr) = _union(new(PersistentHashMap{T, (@compat Void)}()), itr)
+    PersistentSet(d::PersistentHashMap{T, Void}) = new(d)
+    PersistentSet() = new(PersistentHashMap{T, Void}())
+    PersistentSet(itr) = _union(new(PersistentHashMap{T, Void}()), itr)
 end
 PersistentSet() = PersistentSet{Any}()
 PersistentSet(itr) = PersistentSet{eltype(itr)}(itr)
@@ -14,7 +14,7 @@ PersistentSet{T}(x1::T, x2::T, xs::T...) =
                                         [(x, nothing) for x in xs]...))
 
 Base.hash(s::PersistentSet,h::UInt) =
-    hash(s.dict, h+(@compat UInt(0xf7dca1a5fd7090be)))
+    hash(s.dict, h+(UInt(0xf7dca1a5fd7090be)))
 
 Base.conj{T}(s::PersistentSet{T}, val) =
     PersistentSet{T}(assoc(s.dict, val, nothing))
@@ -44,13 +44,13 @@ function Base.filter{T}(f::Function, s::PersistentSet{T})
     PersistentSet{T}(keys(filtered))
 end
 
-function Base.setdiff(l::PersistentSet, r::(@compat Union{PersistentSet, Set}))
+function Base.setdiff(l::PersistentSet, r::( Union{PersistentSet, Set}))
     notinr(el) = !(el in r)
     filter(notinr, l)
 end
 
 import Base.-
--(l::PersistentSet, r::(@compat Union{PersistentSet, Set})) = setdiff(l, r)
+-(l::PersistentSet, r::( Union{PersistentSet, Set})) = setdiff(l, r)
 
 Base.isempty(s::PersistentSet) = length(s.dict) == 0
 
@@ -61,7 +61,7 @@ function _union(s::PersistentSet, xs)
     s
 end
 
-join_eltype() = @compat Union{}
+join_eltype() =  Union{}
 join_eltype(v1, vs...) = typejoin(eltype(v1), join_eltype(vs...))
 
 Base.union(s::PersistentSet) = s


### PR DESCRIPTION
Syntax updating for compatibility with 0.6.0-dev

Almost compatible with 0.5.0, except some problems marked in the test suite. Not sure what to do here:

    julia> PersistentSet(Integer[1,2,3])
    ERROR: MethodError: Cannot `convert` an object of type Pair{Int64,Void} to an object of type Pair{Integer,Void}

or here:

    julia> append(vec(1:31), 32) == vec(1:32)
    true
    julia> @test append(vec(1:31), 32) == vec(1:32)
    [...] ERROR: MethodError: no method matching unsafe_length(::Int64)